### PR TITLE
Null fields breaking S3 to Socrata

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+env_file
+.git
+*.env

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 # this library requires the cx_Oracle package, but we source it from our
 # ready-made Oracle docker container: https://github.com/cityofaustin/atd-oracle-py
 arrow==0.17.*
-boto3==1.14.*
 knackpy==1.0.*
+numpy==1.21.*
+sodapy==2.1.*
+boto3==1.19.*
+pandas==1.3.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,5 @@
 # ready-made Oracle docker container: https://github.com/cityofaustin/atd-oracle-py
 arrow==0.17.*
 knackpy==1.0.*
-numpy==1.21.*
 sodapy==2.1.*
 boto3==1.19.*
-pandas==1.3.*

--- a/s3_to_socrata.py
+++ b/s3_to_socrata.py
@@ -7,8 +7,8 @@ from datetime import datetime, timezone, timedelta
 import json
 import logging
 import os
-import numpy as np
 
+import numpy as np
 import boto3
 import sodapy
 import pandas as pd

--- a/s3_to_socrata.py
+++ b/s3_to_socrata.py
@@ -3,15 +3,12 @@
 Download finance json files and publish them to Socrata
 """
 import argparse
-from datetime import datetime, timezone, timedelta
 import json
 import logging
 import os
 
-import numpy as np
 import boto3
 import sodapy
-import pandas as pd
 
 import utils
 
@@ -64,7 +61,9 @@ def get_dept_unit(client, socrata_client):
 
     """
     response = client.get_object(Bucket=BUCKET_NAME, Key="units.json")
-    data = json.load(response.get("Body"))
+    obj_data = response.get("Body").read().decode()
+    data = json.loads(obj_data)
+
     socrata_client.upsert(DEPT_UNITS_DATASET, data)
     logger.debug("Sent units data to Socrata")
 
@@ -85,56 +84,55 @@ def get_task_orders(client, socrata_client):
 
     """
     response = client.get_object(Bucket=BUCKET_NAME, Key="task_orders.json")
+    obj_data = response.get("Body").read().decode()
+    data = json.loads(obj_data)
 
-    df = pd.read_json(response.get("Body"), orient="records")
     # Transforms the file to fit the Socrata dataset
-    data = transform_records(df)
+    data = transform_records(data)
 
     socrata_client.upsert(TASK_DATASET, data)
     logger.debug("Sent task data to Socrata")
 
 
-def transform_records(df):
+def transform_records(data):
     """
     Transforms the task_orders.json file to be in the same format as the socrata dataset
 
     Parameters
     ----------
-    df : Pandas Dataframe
-        Raw JSON file from S3.
+    data : dict
+        Json file from S3 bucket
 
     Returns
     -------
-    Dict
+    replaced_data : dict
         Transformed file.
 
     """
-    # Replaces NaN float values to None which is needed for Socrata.
-    # Socrata doesn't recognize NaN as a value for number columns
-    df = df.replace({np.nan: None})
+    columns = {
+        "TASK_ORDER_DEPT": "DEPT",
+        "TASK_ORDER_ID": "TASK_ORDER",
+        "TASK_ORDER_DESC": "NAME",
+        "TASK_ORDER_STATUS": "Status",
+        "TASK_ORDER_TYPE": "TK_TYPE",
+        "TK_CURR_AMOUNT": "CURRENT_ESTIMATE",
+        "CHARGED_AMOUNT": "CHARGEDAMOUNT",
+        "TASK_ORDER_BAL": "BALANCE",
+        "BYR_FDU": "BUYER_FDUS",
+    }
 
-    df = df.rename(
-        columns={
-            "TASK_ORDER_DEPT": "DEPT",
-            "TASK_ORDER_ID": "TASK_ORDER",
-            "TASK_ORDER_DESC": "NAME",
-            "TASK_ORDER_STATUS": "Status",
-            "TASK_ORDER_TYPE": "TK_TYPE",
-            "TK_CURR_AMOUNT": "CURRENT_ESTIMATE",
-            "CHARGED_AMOUNT": "CHARGEDAMOUNT",
-            "TASK_ORDER_BAL": "BALANCE",
-            "BYR_FDU": "BUYER_FDUS",
-        }
-    )
+    replaced_data = []
+    for row in data:
+        new_row = {}
+        for src_key, dest_key in columns.items():
+            new_row[dest_key] = row.get(src_key)
+        new_row["DISPLAY_NAME"] = new_row["TASK_ORDER"] + " | " + new_row["NAME"]
+        replaced_data.append(new_row)
 
-    # Creating Display Name field
-    df["DISPLAY_NAME"] = df["TASK_ORDER"] + " | " + df["NAME"]
-
-    return df.to_dict("records")
+    return replaced_data
 
 
 def main(args):
-
     ## Setting up client objects
     aws_s3_client = boto3.client(
         "s3", aws_access_key_id=AWS_ACCESS_ID, aws_secret_access_key=AWS_PASS,

--- a/s3_to_socrata.py
+++ b/s3_to_socrata.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone, timedelta
 import json
 import logging
 import os
+import numpy as np
 
 import boto3
 import sodapy
@@ -88,6 +89,7 @@ def get_task_orders(client, socrata_client):
     df = pd.read_json(response.get("Body"), orient="records")
     # Transforms the file to fit the Socrata dataset
     data = transform_records(df)
+
     socrata_client.upsert(TASK_DATASET, data)
     logger.debug("Sent task data to Socrata")
 
@@ -107,6 +109,9 @@ def transform_records(df):
         Transformed file.
 
     """
+    # Replaces NaN float values to None which is needed for Socrata.
+    # Socrata doesn't recognize NaN as a value for number columns
+    df = df.replace({np.nan: None})
 
     df = df.rename(
         columns={


### PR DESCRIPTION
[8809](https://github.com/cityofaustin/atd-data-tech/issues/8809)

Socrata doesn't like `NaN` records:
`HTTPError: 400 Client Error: Bad Request. invalid input: 1:271428: Unknown identifier "NaN"`

Replacing with `None`:
`df = df.replace({np.nan: None})`

It is affecting only the Task Orders dataset and specifically these columns:
- `TK_CURR_AMOUNT`	
- `CHARGED_AMOUNT`
- `TASK_ORDER_BAL`

Pushed this up to DockerHub and is running in Prefect [here](https://cloud.prefect.io/flow/c9634613-90d8-4762-b8a9-b81f721d3102).

Tested results for Task Order dataset:
`{'Errors': 0, 'Rows Created': 7152, 'Rows Updated': 3572, 'Rows Deleted': 0}`

There are a lot of duplicate `TASK_ORDER_ID's`, we go from 10,724 records to 2,713 in the Socrata dataset because we've set `TASK_ORDER_ID` as the row identifier. Is this working as expected @johnclary?