### PR TITLE
Task Orders for Finance Team

### DIFF
--- a/config.py
+++ b/config.py
@@ -45,39 +45,73 @@ of "app_name" name throughout these scripts as well as in atd-knack-services
 FIELD_MAPS = {
     "task_orders": {
         # any Knack app to be processed must have an object ID defined here
-        "knack_object": {"data-tracker": "object_86",},
+        "knack_object": {
+            "data-tracker": "object_86",
+            "finance-purchasing": "object_43",
+        },
         # see docstring about coalesce in s3_to_knack.py
         "coalesce_fields": ["BYR_FDU"],
         "field_map": [
-            {"src": "TASK_ORDER_DEPT", "data-tracker": "field_1276"},
-            {"src": "TASK_ORDER_ID", "data-tracker": "field_1277", "primary_key": True},
+            {
+                "src": "TASK_ORDER_DEPT", 
+                "data-tracker": "field_1276",
+                "finance-purchasing": "field_988",
+            },
+            {
+                "src": "TASK_ORDER_ID",
+                "data-tracker": "field_1277",
+                "finance-purchasing": "field_989",
+                "primary_key": True,
+            },
             {
                 "src": "TASK_ORDER_DESC",
                 "data-tracker": "field_2632",
+                "finance-purchasing": "field_990",
                 "handler": pad_angle_brackets,
             },
-            {"src": "TASK_ORDER_STATUS", "data-tracker": "field_3810",},
-            {"src": "TASK_ORDER_TYPE", "data-tracker": "field_3580"},
+            {
+                "src": "TASK_ORDER_STATUS", 
+                "data-tracker": "field_3810",
+                "finance-purchasing": "field_992",
+            },
+            {
+                "src": "TASK_ORDER_TYPE", 
+                "data-tracker": "field_3580",
+                "finance-purchasing": "field_994",
+            },
             {
                 "src": "TK_CURR_AMOUNT",
                 "data-tracker": "field_3684",
+                "finance-purchasing": "field_995",
                 "handler": add_comma_separator,
             },
             {
                 "src": "CHARGED_AMOUNT",
                 "data-tracker": "field_3685",
+                "finance-purchasing": "field_996",
                 "handler": add_comma_separator,
             },
             {
                 "src": "TASK_ORDER_BAL",
                 "data-tracker": "field_3686",
+                "finance-purchasing": "field_997",
                 "handler": add_comma_separator,
             },
-            {"src": "BYR_FDU", "data-tracker": "field_3807"},
+            {
+                "src": "TASK_ORDER_ESTIMATOR",
+                "data-tracker": "field_4495",
+                "finance-purchasing": "field_1048",
+            },
+            {
+                "src": "BYR_FDU",
+                "data-tracker": "field_3807",
+                "finance-purchasing": "field_998",
+            },
             {
                 # appends modified date
                 "src": None,
                 "data-tracker": "field_3809",
+                "finance-purchasing": "field_999",
                 "handler": knack_current_timestamp,
                 "ignore_diff": True,
             },

--- a/s3_to_knack.py
+++ b/s3_to_knack.py
@@ -220,9 +220,13 @@ def main():
 
     logging.info(f"{len(todos)} records to process.")
 
+    count = 1
     for record in todos:
+        if count % 10 == 0:
+            logging.info(f"{count} record(s) processed")
         method = "create" if not record.get("id") else "update"
         app.record(data=record, method=method, obj=knack_obj)
+        count += 1
 
 
 if __name__ == "__main__":

--- a/upload_to_s3.py
+++ b/upload_to_s3.py
@@ -43,8 +43,6 @@ def fileobj(list_of_dicts):
 
 
 def get_conn(host, port, service, user, password):
-    #lib_dir = r"/Users/charliehenry/instantclient_19_8"
-    #cx_Oracle.init_oracle_client(lib_dir)
     dsn_tns = cx_Oracle.makedsn(host, port, service_name=service)
     return cx_Oracle.connect(user=user, password=password, dsn=dsn_tns)
 

--- a/upload_to_s3.py
+++ b/upload_to_s3.py
@@ -22,11 +22,14 @@ PORT = os.getenv("PORT")
 SERVICE = os.getenv("SERVICE")
 BUCKET = os.getenv("BUCKET")
 
+AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID")
+AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY")
+
 # we are explicit about the fields we select not only because these views hold data we
 # don't care about but also because any datetime fields would require extra handling in
 # order to JSON-serialize them
 QUERIES = {
-    "task_orders": "select atd_tk.TASK_ORDER_DEPT, atd_tk.TASK_ORDER_ID, atd_tk.TASK_ORDER_DESC, atd_tk.TASK_ORDER_STATUS, atd_tk.TASK_ORDER_TYPE, atd_tk.TK_CURR_AMOUNT, atd_tk.CHARGED_AMOUNT, atd_tk.TASK_ORDER_BAL, buyer_tk.BYR_FDU FROM DEPT_2400_TK_VW atd_tk LEFT JOIN( SELECT DISTINCT TASK_ORD_CD, BYR_FDU FROM REL_BUYER_SELLER_FDU_TK) buyer_tk ON atd_tk.TASK_ORDER_ID = buyer_tk.TASK_ORD_CD where TASK_ORDER_STATUS is not null",
+    "task_orders": "select atd_tk.TASK_ORDER_DEPT, atd_tk.TASK_ORDER_ID, atd_tk.TASK_ORDER_DESC, atd_tk.TASK_ORDER_STATUS, atd_tk.TASK_ORDER_TYPE, atd_tk.TK_CURR_AMOUNT, atd_tk.CHARGED_AMOUNT, atd_tk.TASK_ORDER_BAL, atd_tk.TASK_ORDER_ESTIMATOR, buyer_tk.BYR_FDU FROM DEPT_2400_TK_VW atd_tk LEFT JOIN( SELECT DISTINCT TASK_ORD_CD, BYR_FDU FROM REL_BUYER_SELLER_FDU_TK) buyer_tk ON atd_tk.TASK_ORDER_ID = buyer_tk.TASK_ORD_CD where TASK_ORDER_STATUS is not null",
     "units": "select DEPT_UNIT_ID, DEPT_ID, DEPT, UNIT, UNIT_LONG_NAME, UNIT_SHORT_NAME, DEPT_UNIT_STATUS from lu_dept_units WHERE DEPT in(2400,6207,2507)",
     "objects": "select OBJ_ID, OBJ_CLASS_ID, OBJ_CATEGORY_ID, OBJ_TYPE_ID, OBJ_GROUP_ID, OBJ_CODE, OBJ_LONG_NAME, OBJ_SHORT_NAME, OBJ_DESC, OBJ_REIMB_ELIG_STATUS, OBJ_STATUS, ACT_FL from lu_obj_cd",
     "master_agreements": "select DOC_CD, DOC_DEPT_CD, DOC_ID, DOC_DSCR, DOC_PHASE_CD, VEND_CUST_CD, LGL_NM from DEPT_2400_MA_VW",
@@ -40,6 +43,8 @@ def fileobj(list_of_dicts):
 
 
 def get_conn(host, port, service, user, password):
+    #lib_dir = r"/Users/charliehenry/instantclient_19_8"
+    #cx_Oracle.init_oracle_client(lib_dir)
     dsn_tns = cx_Oracle.makedsn(host, port, service_name=service)
     return cx_Oracle.connect(user=user, password=password, dsn=dsn_tns)
 
@@ -85,8 +90,8 @@ def main():
 
     file = fileobj(rows)
     file_name = f"{name}.json"
-    session = boto3.session.Session()
-    client = session.client("s3")
+    session = boto3.session.Session(aws_access_key_id=AWS_ACCESS_KEY_ID,aws_secret_access_key=AWS_SECRET_ACCESS_KEY)
+    client = session.client("s3",aws_access_key_id=AWS_ACCESS_KEY_ID,aws_secret_access_key=AWS_SECRET_ACCESS_KEY)
     client.upload_fileobj(
         file, BUCKET, file_name,
     )


### PR DESCRIPTION
Issue: https://github.com/cityofaustin/atd-data-tech/issues/10111

- Adds the `TASK_ORDER_ESTIMATOR` field to the `data-tracker` app. 
- Along with creating another config for an identical object in the `finance-purchasing` app.
- Added some additional logging for when `s3_to_knack.py` takes a while.

ETL will be be created in Prefect (WIP). Airflow currently only runs the task orders ETL for the `data-tracker` app.