### PR TITLE
Compare lists regardless of order

### DIFF
--- a/config.py
+++ b/config.py
@@ -34,6 +34,15 @@ def knack_current_timestamp(val, tz="US/Central"):
     ISO datestring in local time without the timezone offset, or a "local" timestamp"""
     return arrow.now(tz).format("YYYY-MM-DDTHH:mm:ss")
 
+def string_list_order(value):
+    """Input list stored as string is sorted into a consistent order"""
+    if isinstance(value, str):
+        unique_sorted = list(value.split(",\n"))
+        unique_sorted.sort()
+        return ",\n".join(unique_sorted)
+    else:
+        return None
+
 
 """
 Each top level key must be a financial record type. you probably dont want to mess w/
@@ -105,6 +114,7 @@ FIELD_MAPS = {
                 "src": "BYR_FDU",
                 "data-tracker": "field_3807",
                 "finance-purchasing": "field_998",
+                "handler": string_list_order,
             },
             {
                 # appends modified date

--- a/s3_to_knack.py
+++ b/s3_to_knack.py
@@ -68,17 +68,8 @@ def get_pks(fields, app_name):
 
 
 def is_equal(rec_current, rec_knack, keys):
-    for key in keys:
-        # Comparing comma separated lists regardless of order
-        if isinstance(rec_current[key], str) and isinstance(rec_knack[key], str):
-            if ",\n" in rec_current[key] and ",\n" in rec_knack[key]:
-                if set(rec_current[key].split(",\n")) != set(rec_knack[key].split(",\n")):
-                    return False
-            elif rec_current[key] != rec_knack[key]:
-                return False
-        elif rec_current[key] != rec_knack[key]:
-            return False
-    return True
+    tests = [rec_current[key] == rec_knack[key] for key in keys]
+    return all(tests)
 
 
 def create_mapped_record(rec_current, field_map, app_name):

--- a/s3_to_knack.py
+++ b/s3_to_knack.py
@@ -68,8 +68,17 @@ def get_pks(fields, app_name):
 
 
 def is_equal(rec_current, rec_knack, keys):
-    tests = [rec_current[key] == rec_knack[key] for key in keys]
-    return all(tests)
+    for key in keys:
+        # Comparing comma separated lists regardless of order
+        if isinstance(rec_current[key], str) and isinstance(rec_knack[key], str):
+            if ",\n" in rec_current[key] and ",\n" in rec_knack[key]:
+                if set(rec_current[key].split(",\n")) != set(rec_knack[key].split(",\n")):
+                    return False
+            elif rec_current[key] != rec_knack[key]:
+                return False
+        elif rec_current[key] != rec_knack[key]:
+            return False
+    return True
 
 
 def create_mapped_record(rec_current, field_map, app_name):
@@ -180,7 +189,7 @@ def main():
     record_type = args.name
     app_name = args.dest
     
-    # get latest finance records from AWS S3
+    # get the latest finance records from AWS S3
     logging.info(f"Downloading {record_type} records from S3...")
 
     records_current_unfiltered = download_json(


### PR DESCRIPTION
We were updating roughly 10% of all of our knack records every time we ran s3_to_knack.py. This caused a lot of knack API activity and potentially caused us to get rate limited.

Compares string lists differently, so we the order provided by the finance DB or Knack doesn't matter.

Example of a list that would currently get flagged as a changed record:
Knack:
`820B 2507 D711,\n4730 2507 M104`
Finance DB
`4730 2507 M104,\n820B 2507 D711`