### PR TITLE
update docker deploy actions

### DIFF
--- a/.github/workflows/docker-image-build-push.yml
+++ b/.github/workflows/docker-image-build-push.yml
@@ -3,7 +3,8 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [production, staging]
+    branches: 
+      - production
 
 jobs:
   main:
@@ -11,18 +12,19 @@ jobs:
     steps:
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       -
         name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v2 
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          password: ${{ secrets.DOCKER_TOKEN }}
       -
         name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/atd-finance-data:production


### PR DESCRIPTION
Based on what John did over in [atd-executive-dashboard](https://github.com/cityofaustin/atd-executive-dashboard/blob/main/.github/workflows/docker-image-build-push.yml) to get these atd-oracle-py images to run locally on M1 macs. I've already updated repo secrets to add `DOCKER_TOKEN`.  I think this is all that is needed here?