### PR TITLE
FDU program tagging

### DIFF
--- a/program_tagging/fdu_program_tagging.py
+++ b/program_tagging/fdu_program_tagging.py
@@ -1,0 +1,63 @@
+import os
+import json
+import logging
+
+import boto3
+
+import utils
+from prefix_maps import prefix_mapping
+
+AWS_ACCESS_ID = os.getenv("AWS_ACCESS_KEY_ID")
+AWS_PASS = os.getenv("AWS_SECRET_ACCESS_KEY")
+BUCKET_NAME = os.getenv("BUCKET")
+
+
+def get_data(client):
+    """
+    Gets the subprojects.json file and sends the data to socrata
+
+    Parameters
+    ----------
+    client : AWS Client object
+
+    socrata_client : Socrata client object
+
+    Returns
+    -------
+    None.
+
+    """
+    response = client.get_object(Bucket=BUCKET_NAME, Key="fdu_expenses_obligated.json")
+    obj_data = response.get("Body").read().decode()
+    data = json.loads(obj_data)
+    return data
+
+
+def tag_programs(data):
+    for row in data:
+        row["id"] = (
+            row["DEPT"] + row["FUND"] + row["LVL1_DIV_CODE"] + row["LVL2_GP_CODE"]
+        )
+        for prefix in prefix_mapping:
+            if row["id"].startswith(prefix):
+                row["program"] = prefix_mapping[prefix]["program"]
+                row["subprogram"] = prefix_mapping[prefix]["subprogram"]
+                row["bond_year"] = prefix_mapping[prefix]["bond_year"]
+    return data
+
+
+def main():
+    aws_s3_client = boto3.client(
+        "s3",
+        aws_access_key_id=AWS_ACCESS_ID,
+        aws_secret_access_key=AWS_PASS,
+    )
+    data = get_data(aws_s3_client)
+    data = tag_programs(data)
+    data
+
+
+if __name__ == "__main__":
+    logger = utils.get_logger(__name__, level=logging.INFO)
+
+    main()

--- a/program_tagging/fdu_program_tagging.py
+++ b/program_tagging/fdu_program_tagging.py
@@ -3,6 +3,7 @@ import json
 import logging
 
 import boto3
+import sodapy
 
 import utils
 from prefix_maps import prefix_mapping
@@ -10,6 +11,13 @@ from prefix_maps import prefix_mapping
 AWS_ACCESS_ID = os.getenv("AWS_ACCESS_KEY_ID")
 AWS_PASS = os.getenv("AWS_SECRET_ACCESS_KEY")
 BUCKET_NAME = os.getenv("BUCKET")
+
+SO_WEB = os.getenv("SO_WEB")
+SO_TOKEN = os.getenv("SO_TOKEN")
+SO_USER = os.getenv("SO_USER")
+SO_PASS = os.getenv("SO_PASS")
+
+DATASET = os.getenv("PROGRAM_DATASET")
 
 
 def get_data(client):
@@ -52,9 +60,18 @@ def main():
         aws_access_key_id=AWS_ACCESS_ID,
         aws_secret_access_key=AWS_PASS,
     )
+    socrata_client = sodapy.Socrata(
+        SO_WEB,
+        SO_TOKEN,
+        username=SO_USER,
+        password=SO_PASS,
+        timeout=60,
+    )
+
     data = get_data(aws_s3_client)
     data = tag_programs(data)
-    data
+    res = socrata_client.replace(DATASET, data)
+    print(res)
 
 
 if __name__ == "__main__":

--- a/program_tagging/prefix_maps.py
+++ b/program_tagging/prefix_maps.py
@@ -1,0 +1,172 @@
+prefix_mapping = {
+    "25078119C001": {
+        "program": "Corridor Program",
+        "subprogram": "Corridor Program",
+        "bond_year": 2016,
+    },
+    "25078119L001L010": {
+        "program": "Bikeways",
+        "subprogram": "Bikeways",
+        "bond_year": 2016,
+    },
+    "25078119L001L030": {
+        "program": "Vision Zero",
+        "subprogram": "Intersection Safety",
+        "bond_year": 2016,
+    },
+    "25078119L001L100": {
+        "program": "Substandard Streets",
+        "subprogram": "Substandard Streets",
+        "bond_year": 2016,
+    },
+    "25078119R001": {
+        "program": "Regional Mobility",
+        "subprogram": "Regional Mobility",
+        "bond_year": 2016,
+    },
+    "62078119L001": {
+        "program": "Sidewalks",
+        "subprogram": "Sidewalks",
+        "bond_year": 2016,
+    },
+    "62078119L100": {
+        "program": "Safe Routes",
+        "subprogram": "Safe Routes",
+        "bond_year": 2016,
+    },
+    "62078119L200": {
+        "program": "Urban Trails",
+        "subprogram": "Urban Trails",
+        "bond_year": 2016,
+    },
+    "62078119L300": {
+        "program": "Capital Renewal",
+        "subprogram": "Capital Renewal",
+        "bond_year": 2016,
+    },
+    "25078127B100": {
+        "program": "Traffic Signals",
+        "subprogram": "Traffic Signals",
+        "bond_year": 2018,
+    },
+    "25078127B110": {
+        "program": "Vision Zero",
+        "subprogram": "Intersection Safety",
+        "bond_year": 2018,
+    },
+    "25078127B140": {
+        "program": "Vision Zero",
+        "subprogram": "Pedestrian Safety",
+        "bond_year": 2018,
+    },
+    "62078127B001": {
+        "program": "Street Programs",
+        "subprogram": "Street Programs",
+        "bond_year": 2018,
+    },
+    "62078127B100": {
+        "program": "Bridges & Structures",
+        "subprogram": "Bridges & Structures",
+        "bond_year": 2018,
+    },
+    "62078127B200": {
+        "program": "Sidewalks",
+        "subprogram": "Sidewalks",
+        "bond_year": 2018,
+    },
+    "62078127B300": {
+        "program": "Urban Trails",
+        "subprogram": "Urban Trails",
+        "bond_year": 2018,
+    },
+    "62078127B400": {
+        "program": "Neighborhood Partnering",
+        "subprogram": "Neighborhood Partnering",
+        "bond_year": 2018,
+    },
+    "2507820BD001": {
+        "program": "Bikeways",
+        "subprogram": "Bikeways",
+        "bond_year": 2020,
+    },
+    "2507820BD003D300": {
+        "program": "Vision Zero",
+        "subprogram": "Signal Safety",
+        "bond_year": 2020,
+    },
+    "2507820BD003D400": {
+        "program": "Vision Zero",
+        "subprogram": "Pedestrian Safety",
+        "bond_year": 2020,
+    },
+    "2507820BD003D500": {
+        "program": "Vision Zero",
+        "subprogram": "Major Safety",
+        "bond_year": 2020,
+    },
+    "2507820BD003D600": {
+        "program": "Vision Zero",
+        "subprogram": "Speed Management",
+        "bond_year": 2020,
+    },
+    "2507820BD007D700": {
+        "program": "Local Transit",
+        "subprogram": "Local Transit Enhancement",
+        "bond_year": 2020,
+    },
+    "2507820BD007D730": {
+        "program": "Local Transit",
+        "subprogram": "Signal Priority",
+        "bond_year": 2020,
+    },
+    "2507820BD007D740": {
+        "program": "Local Transit",
+        "subprogram": "Signal Cabinet Security",
+        "bond_year": 2020,
+    },
+    "2507820BD007D750": {
+        "program": "Local Transit",
+        "subprogram": "Micro Mobility",
+        "bond_year": 2020,
+    },
+    "2507820BD007D760": {
+        "program": "Local Transit",
+        "subprogram": "Smart Mobility",
+        "bond_year": 2020,
+    },
+    "2507820BD008": {
+        "program": "Substandard Streets",
+        "subprogram": "Substandard Streets",
+        "bond_year": 2020,
+    },
+    "2507820BD009": {
+        "program": "Capital Renewal",
+        "subprogram": "Capital Renewal",
+        "bond_year": 2020,
+    },
+    "6207820BD000": {
+        "program": "Sidewalks",
+        "subprogram": "Sidewalks",
+        "bond_year": 2020,
+    },
+    "6207820BDCI0": {
+        "program": "Capital Renewal",
+        "subprogram": "Capital Renewal",
+        "bond_year": 2020,
+    },
+    "6207820BDN00": {
+        "program": "Neighborhood Partnering",
+        "subprogram": "Neighborhood Partnering",
+        "bond_year": 2020,
+    },
+    "6207820BDSR0": {
+        "program": "Safe Routes",
+        "subprogram": "Safe Routes",
+        "bond_year": 2020,
+    },
+    "6207820BDT00": {
+        "program": "Urban Trails",
+        "subprogram": "Urban Trails",
+        "bond_year": 2020,
+    },
+}

--- a/queries.py
+++ b/queries.py
@@ -93,7 +93,7 @@ QUERIES = {
         ATD_SUBPROJECT_FDU_VW
 	""",
     "subprojects": """
-        SELECT
+    SELECT
         PROJECT_NUMBER,
         SP_NUMBER_TXT,
         SP_NAME,
@@ -105,4 +105,30 @@ QUERIES = {
     FROM
         MSTR_IA_DEV.DEPT_2400_SUBPRJ_VW
 	""",
+    "fdu_expenses_obligated": """
+    SELECT 
+        FDU,
+        FDU_STATUS,
+        FUND,
+        FUND_LONG_NAME,
+        DEPT,
+        DEPT_LONG_NAME,
+        LVL1_DIV_CODE,
+        LVL1_DIV_LONG_NAME,
+        LVL2_GP_CODE,
+        LVL2_GP_LONG_NAME,
+        UNIT,
+        UNIT_LONG_NAME,
+        FAO_ID,
+        SP_NUMBER,
+        SP_NAME,
+        SP_STATUS,
+        APP,
+        ENC,
+        EXP,
+        OBL,
+        FDU_BAL
+    FROM
+        MSTR_IA_DEV.ATD_FDUS_VW
+    """,
 }

--- a/queries.py
+++ b/queries.py
@@ -122,12 +122,7 @@ QUERIES = {
         FAO_ID,
         SP_NUMBER,
         SP_NAME,
-        SP_STATUS,
-        APP,
-        ENC,
-        EXP,
-        OBL,
-        FDU_BAL
+        SP_STATUS
     FROM
         MSTR_IA_DEV.ATD_FDUS_VW
     """,

--- a/queries.py
+++ b/queries.py
@@ -122,7 +122,8 @@ QUERIES = {
         FAO_ID,
         SP_NUMBER,
         SP_NAME,
-        SP_STATUS
+        SP_STATUS,
+        'https://ecapris.austintexas.gov/index.cfm?fuseaction=fdus.fduData&fdu_ID=' || FAO_ID as ecapris_link
     FROM
         MSTR_IA_DEV.ATD_FDUS_VW
     """,


### PR DESCRIPTION
Part of: https://github.com/cityofaustin/atd-data-tech/issues/22686

Adds a script fdu_program_tagging.py which uses a set of prefixes to tag FDU's program and subprogram. I got these prefixes from a spreadsheet that Meredith Q originally created and is now maintained by Chris G at PDD. This should allow us to tag new FDUs immediately without having to manually add each one to the spreadsheet each time one is created.

[Dataset is here](https://datahub.austintexas.gov/dataset/TPW-Program-and-Subprogram-by-FDU/s4mj-68pg/about_data)
