### PR TITLE
add spending columns to FDU query

### DIFF
--- a/queries.py
+++ b/queries.py
@@ -123,7 +123,12 @@ QUERIES = {
         SP_NUMBER,
         SP_NAME,
         SP_STATUS,
-        'https://ecapris.austintexas.gov/index.cfm?fuseaction=fdus.fduData&fdu_ID=' || FAO_ID as ecapris_link
+        'https://ecapris.austintexas.gov/index.cfm?fuseaction=fdus.fduData&fdu_ID=' || FAO_ID as ecapris_link,
+        APP,
+        EXP,
+        OBL,
+        ENC,
+        FDU_BAL
     FROM
         MSTR_IA_DEV.ATD_FDUS_VW
     """,


### PR DESCRIPTION
https://github.com/cityofaustin/atd-data-tech/issues/23675

OPM is relying on an older bond reporting dataset that we have since spun down. Adding spending columns to this data allows us to replace this old dataset with a new [view](https://datahub.austintexas.gov/dataset/TPWstat-Current-Bond-Spending-by-Program/sbrw-z9js/about_data).

[Dataset](https://datahub.austintexas.gov/dataset/TPW-Program-and-Subprogram-by-FDU/s4mj-68pg/about_data)